### PR TITLE
Make state info output text box non-interactive

### DIFF
--- a/stable_diffusion_2_0.ipynb
+++ b/stable_diffusion_2_0.ipynb
@@ -533,7 +533,7 @@
         "                generate = gr.Button(value=\"Generate\").style(rounded=(False, True, True, False))\n",
         "\n",
         "              gallery = gr.Gallery(label=\"Generated images\", show_label=False).style(grid=[2], height=\"auto\")\n",
-        "          state_info = gr.Textbox(label=\"State\", show_label=False, max_lines=2).style(container=False)\n",
+        "          state_info = gr.Textbox(label=\"State\", show_label=False, max_lines=2, interactive=false).style(container=False)\n",
         "          error_output = gr.Markdown(visible=False)\n",
         "\n",
         "        with gr.Column(scale=30):\n",


### PR DESCRIPTION
its purely a minor annoyance and not anything of value, but without this flag set I accidentally typed over my own seed value a few times. this should change nothing but to make that state output text book non-writable